### PR TITLE
Translate reflection notebook to Korean

### DIFF
--- a/docs/docs/tutorials/reflection/reflection.ipynb
+++ b/docs/docs/tutorials/reflection/reflection.ipynb
@@ -10,15 +10,15 @@
    "id": "492f050f-3dc3-44fa-8fdc-03362afd5488",
    "metadata": {},
    "source": [
-    "# Reflection\n",
+    "# 리플렉션\n",
     "\n",
     "\n",
-    "In the context of LLM agent building, reflection refers to the process of prompting an LLM to observe its past steps (along with potential observations from tools/the environment) to assess the quality of the chosen actions.\n",
-    "This is then used downstream for things like re-planning, search, or evaluation.\n",
+    "LLM 에이전트를 만들 때 리플렉션은 LLM에게 자신이 수행했던 과정을(도구나 환경으로부터 얻은 관찰 결과와 함께) 되돌아보도록 하여 선택한 행동의 품질을 평가하도록 하는 과정을 의미합니다.\n",
+    "이렇게 평가된 결과는 이후 재계획, 검색 또는 평가 등의 단계에서 활용됩니다.\n",
     "\n",
     "![Reflection](attachment:fc393f72-3401-4b86-b0d3-e4789b640a27.png)\n",
     "\n",
-    "This notebook demonstrates a very simple form of reflection in LangGraph."
+    "이 노트북은 LangGraph에서 아주 단순한 형태의 리플렉션을 시연합니다."
    ]
   },
   {
@@ -26,9 +26,9 @@
    "id": "3ef94e7e-c9a5-4eee-a865-acf411b5c235",
    "metadata": {},
    "source": [
-    "## Setup\n",
+    "## 설정\n",
     "\n",
-    "First, let's install our required packages and set our API keys"
+    "먼저 필요한 패키지를 설치하고 API 키를 설정해봅시다"
    ]
   },
   {
@@ -69,9 +69,9 @@
    "metadata": {},
    "source": [
     "<div class=\"admonition tip\">\n",
-    "    <p class=\"admonition-title\">Set up <a href=\"https://smith.langchain.com\">LangSmith</a> for LangGraph development</p>\n",
+    "    <p class=\"admonition-title\"><a href=\"https://smith.langchain.com\">LangSmith</a>를 설정하여 LangGraph 개발을 시작하세요</p>\n",
     "    <p style=\"padding-top: 5px;\">\n",
-    "        Sign up for LangSmith to quickly spot issues and improve the performance of your LangGraph projects. LangSmith lets you use trace data to debug, test, and monitor your LLM apps built with LangGraph — read more about how to get started <a href=\"https://docs.smith.langchain.com\">here</a>. \n",
+    "        LangSmith에 가입하면 LangGraph 프로젝트의 문제를 빠르게 발견하고 성능을 개선할 수 있습니다. LangSmith는 추적 데이터를 활용해 LangGraph로 만든 LLM 앱을 디버그, 테스트, 모니터링할 수 있게 해줍니다. 시작 방법은 <a href=\"https://docs.smith.langchain.com\">여기</a>에서 확인하세요. \n",
     "    </p>\n",
     "</div>"
    ]
@@ -81,9 +81,9 @@
    "id": "f27bcc4a-aaa5-46bd-8163-3e0e90cb66e6",
    "metadata": {},
    "source": [
-    "## Generate\n",
+    "## 생성\n",
     "\n",
-    "For our example, we will create a \"5 paragraph essay\" generator. First, create the generator:\n"
+    "우리 예제에서는 \"5단락 에세이\"를 생성하는 도구를 만들어보겠습니다. 먼저 생성기를 만듭니다:\n"
    ]
   },
   {
@@ -161,7 +161,7 @@
    "id": "b0b276e7-c392-4eec-be75-c77bd130379d",
    "metadata": {},
    "source": [
-    "### Reflect"
+    "### 반영"
    ]
   },
   {
@@ -238,9 +238,9 @@
    "id": "6daf926c-1174-4e96-91b9-57c57cfce40d",
    "metadata": {},
    "source": [
-    "### Repeat\n",
+    "### 반복\n",
     "\n",
-    "And... that's all there is too it! You can repeat in a loop for a fixed number of steps, or use an LLM (or other check) to decide when the finished product is good enough."
+    "이것으로 모든 과정이 끝입니다! 정해진 횟수만큼 반복하거나, LLM(또는 다른 검사)을 사용하여 결과물이 충분히 좋다고 판단될 때까지 반복할 수 있습니다."
    ]
   },
   {
@@ -307,9 +307,9 @@
    "id": "b63a9d93-a14d-4e41-a4bb-a4cd31713f44",
    "metadata": {},
    "source": [
-    "## Define graph\n",
+    "## 그래프 정의\n",
     "\n",
-    "Now that we've shown each step in isolation, we can wire it up in a graph."
+    "각 단계를 개별적으로 살펴보았으니 이제 그래프로 연결해 봅시다."
    ]
   },
   {
@@ -605,9 +605,9 @@
     "jp-MarkdownHeadingCollapsed": true
    },
    "source": [
-    "## Conclusion\n",
+    "## 결론\n",
     "\n",
-    "Now that you've applied reflection to an LLM agent, I'll note one thing: self-reflection is inherently cyclic: it is much more effective if the reflection step has additional context or feedback (from tool observations, checks, etc.). If, like in the scenario above, the reflection step simply prompts the LLM to reflect on its output, it can still benefit the output quality (since the LLM then has multiple \"shots\" at getting a good output), but it's less guaranteed.\n"
+    "이제 리플렉션을 LLM 에이전트에 적용했으니 한 가지를 덧붙입니다: 자기 반성은 본질적으로 순환적입니다. 도구에서 얻은 관찰이나 다른 검증으로부터 추가적인 맥락이나 피드백이 주어지면 훨씬 더 효과적입니다. 위의 예처럼 단순히 LLM에게 자신의 출력에 대해 반성하도록 지시하는 경우에도 출력 품질이 향상될 수 있지만(LLM이 좋은 결과를 얻을 기회를 여러 번 갖기 때문입니다) 그 효과가 보장되지는 않습니다.\n"
    ]
   }
  ],

--- a/examples/reflection/reflection.ipynb
+++ b/examples/reflection/reflection.ipynb
@@ -5,7 +5,7 @@
    "id": "658773a2",
    "metadata": {},
    "source": [
-    "This file has been moved to https://github.com/langchain-ai/langgraph/blob/main/docs/docs/tutorials/reflection/reflection.ipynb"
+    "이 파일은 https://github.com/langchain-ai/langgraph/blob/main/docs/docs/tutorials/reflection/reflection.ipynb 로 이동되었습니다"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- localize `reflection.ipynb` notebook content into Korean
- update the example link notebook message in Korean

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f8ff518148325ba1acd617edaf2b2