### PR TITLE
Translate plan-and-execute tutorial to Korean

### DIFF
--- a/docs/docs/tutorials/plan-and-execute/plan-and-execute.ipynb
+++ b/docs/docs/tutorials/plan-and-execute/plan-and-execute.ipynb
@@ -10,27 +10,22 @@
    "id": "79b5811c-1074-495f-9722-8325b5e717d3",
    "metadata": {},
    "source": [
-    "# Plan-and-Execute\n",
+    "# 계획 후 실행 (Plan-and-Execute)\n",
     "\n",
-    "This notebook shows how to create a \"plan-and-execute\" style agent. This is heavily inspired by the [Plan-and-Solve](https://arxiv.org/abs/2305.04091) paper as well as the [Baby-AGI](https://github.com/yoheinakajima/babyagi) project.\n",
+    "이 노트북은 \"계획 후 실행\" 방식의 에이전트를 만드는 방법을 보여줍니다. 이는 [Plan-and-Solve](https://arxiv.org/abs/2305.04091) 논문과 [Baby-AGI](https://github.com/yoheinakajima/babyagi) 프로젝트에서 많은 영감을 받았습니다.\n",
     "\n",
-    "The core idea is to first come up with a multi-step plan, and then go through that plan one item at a time.\n",
-    "After accomplishing a particular task, you can then revisit the plan and modify as appropriate.\n",
+    "핵심 아이디어는 먼저 여러 단계로 구성된 계획을 세운 뒤 그 계획을 한 단계씩 차례로 수행하는 것입니다. 특정 작업을 완료한 뒤에는 계획을 다시 검토하여 필요에 따라 수정할 수 있습니다.\n",
     "\n",
-    "\n",
-    "The general computational graph looks like the following:\n",
+    "전체 계산 그래프는 다음과 같습니다:\n",
     "\n",
     "![plan-and-execute diagram](attachment:86cf6404-3d9b-41cb-ab97-5e451f576620.png)\n",
     "\n",
+    "이는 한 번에 한 단계씩 생각하는 전통적인 [ReAct](https://arxiv.org/abs/2210.03629) 방식의 에이전트를 사용하는 경우와 비교됩니다. \"계획 후 실행\" 방식의 장점은 다음과 같습니다:\n",
     "\n",
-    "This compares to a typical [ReAct](https://arxiv.org/abs/2210.03629) style agent where you think one step at a time.\n",
-    "The advantages of this \"plan-and-execute\" style agent are:\n",
+    "1. 강력한 LLM이라도 어려워하는 장기 계획을 명시적으로 세울 수 있습니다.\n",
+    "2. 실행 단계에서는 더 작은 모델을 사용하고, 계획 단계에서만 더 큰 모델을 사용할 수 있습니다.\n",
     "\n",
-    "1. Explicit long term planning (which even really strong LLMs can struggle with)\n",
-    "2. Ability to use smaller/weaker models for the execution step, only using larger/better models for the planning step\n",
-    "\n",
-    "\n",
-    "The following walkthrough demonstrates how to do so in LangGraph. The resulting agent will leave a trace like the following example: ([link](https://smith.langchain.com/public/d46e24d3-dda6-44d5-9550-b618fca4e0d4/r))."
+    "다음 설명에서는 LangGraph에서 이를 구현하는 방법을 보여 줍니다. 결과로 만들어진 에이전트의 예시는 다음 링크에서 볼 수 있습니다: ([link](https://smith.langchain.com/public/d46e24d3-dda6-44d5-9550-b618fca4e0d4/r))."
    ]
   },
   {
@@ -38,9 +33,9 @@
    "id": "a44a72d6-7e0c-4478-9d20-4c09000420a8",
    "metadata": {},
    "source": [
-    "## Setup\n",
+    "## 설정\n",
     "\n",
-    "First, we need to install the packages required."
+    "먼저 필요한 패키지를 설치합니다.\n"
    ]
   },
   {
@@ -59,7 +54,7 @@
    "id": "35f267b0-98db-4a59-8b2c-a23f795576ff",
    "metadata": {},
    "source": [
-    "Next, we need to set API keys for OpenAI (the LLM we will use) and Tavily (the search tool we will use)"
+    "다음으로 사용할 LLM인 OpenAI와 검색 도구인 Tavily의 API 키를 설정합니다.\n"
    ]
   },
   {
@@ -88,11 +83,11 @@
    "metadata": {},
    "source": [
     "<div class=\"admonition tip\">\n",
-    "    <p class=\"admonition-title\">Set up <a href=\"https://smith.langchain.com\">LangSmith</a> for LangGraph development</p>\n",
+    "    <p class=\"admonition-title\"><a href=\"https://smith.langchain.com\">LangSmith</a> 설정</p>\n",
     "    <p style=\"padding-top: 5px;\">\n",
-    "        Sign up for LangSmith to quickly spot issues and improve the performance of your LangGraph projects. LangSmith lets you use trace data to debug, test, and monitor your LLM apps built with LangGraph — read more about how to get started <a href=\"https://docs.smith.langchain.com\">here</a>. \n",
+    "        LangSmith에 가입하면 LangGraph 프로젝트의 문제를 빠르게 찾고 성능을 향상시킬 수 있습니다. LangSmith는 추적 데이터를 활용해 LangGraph로 만든 LLM 앱을 디버그하고 테스트하며 모니터링할 수 있게 해 줍니다. 시작 방법은 <a href=\"https://docs.smith.langchain.com\">여기</a>에서 확인하세요.\n",
     "    </p>\n",
-    "</div>"
+    "</div>\n"
    ]
   },
   {
@@ -100,9 +95,9 @@
    "id": "6c5fb09a-0311-44c2-b243-d0e80de78902",
    "metadata": {},
    "source": [
-    "## Define Tools\n",
+    "## 도구 정의\n",
     "\n",
-    "We will first define the tools we want to use. For this simple example, we will use a built-in search tool via Tavily. However, it is really easy to create your own tools - see documentation [here](https://python.langchain.com/docs/how_to/custom_tools) on how to do that."
+    "먼저 사용할 도구를 정의합니다. 이 예제에서는 Tavily를 통한 기본 제공 검색 도구를 사용합니다. 자체 도구를 만드는 방법은 [문서](https://python.langchain.com/docs/how_to/custom_tools)를 참고하세요.\n"
    ]
   },
   {
@@ -122,10 +117,9 @@
    "id": "3dcda478-fa80-4e3e-bb35-0f622fe73a31",
    "metadata": {},
    "source": [
-    "## Define our Execution Agent\n",
+    "## 실행 에이전트 정의\n",
     "\n",
-    "Now we will create the execution agent we want to use to execute tasks. \n",
-    "Note that for this example, we will be using the same execution agent for each task, but this doesn't HAVE to be the case."
+    "이제 작업을 실행할 에이전트를 만듭니다. 이 예제에서는 모든 작업에 같은 실행 에이전트를 사용하지만 꼭 그래야 하는 것은 아닙니다.\n"
    ]
   },
   {
@@ -141,7 +135,7 @@
     "\n",
     "# Choose the LLM that will drive the agent\n",
     "llm = ChatOpenAI(model=\"gpt-4-turbo-preview\")\n",
-    "prompt = \"You are a helpful assistant.\"\n",
+    "prompt = \"당신은 도움이 되는 어시스턴트입니다.\"\n",
     "agent_executor = create_react_agent(llm, tools, prompt=prompt)"
    ]
   },
@@ -166,7 +160,7 @@
     }
    ],
    "source": [
-    "agent_executor.invoke({\"messages\": [(\"user\", \"who is the winnner of the us open\")]})"
+    "agent_executor.invoke({\"messages\": [(\"user\", \"US 오픈 우승자는 누구인가요?\")]})"
    ]
   },
   {
@@ -174,15 +168,15 @@
    "id": "5cf66804-44b2-4904-b1a7-17ad70b551f5",
    "metadata": {},
    "source": [
-    "## Define the State\n",
+    "## 상태 정의\n",
     "\n",
-    "Let's now start by defining the state the track for this agent.\n",
+    "이제 이 에이전트가 관리할 상태를 정의해 보겠습니다.\n",
     "\n",
-    "First, we will need to track the current plan. Let's represent that as a list of strings.\n",
+    "먼저 현재 계획을 추적해야 합니다. 이는 문자열 리스트로 표현합니다.\n",
     "\n",
-    "Next, we should track previously executed steps. Let's represent that as a list of tuples (these tuples will contain the step and then the result)\n",
+    "다음으로 이전에 실행한 단계를 추적해야 합니다. 이는 단계와 그 결과를 담은 튜플 리스트로 표현합니다.\n",
     "\n",
-    "Finally, we need to have some state to represent the final response as well as the original input."
+    "마지막으로 최종 응답과 원래 입력을 저장할 상태도 필요합니다.\n"
    ]
   },
   {
@@ -209,9 +203,9 @@
    "id": "1dbd770a-9941-40a9-977e-4d55359eee21",
    "metadata": {},
    "source": [
-    "## Planning Step\n",
+    "## 계획 단계\n",
     "\n",
-    "Let's now think about creating the planning step. This will use function calling to create a plan."
+    "이제 계획 단계를 만들어 보겠습니다. 함수 호출을 사용해 계획을 작성합니다.\n"
    ]
   },
   {
@@ -220,11 +214,11 @@
    "metadata": {},
    "source": [
     "<div class=\"admonition note\">\n",
-    "    <p class=\"admonition-title\">Using Pydantic with LangChain</p>\n",
+    "    <p class=\"admonition-title\">LangChain에서 Pydantic 사용</p>\n",
     "    <p>\n",
-    "        This notebook uses Pydantic v2 <code>BaseModel</code>, which requires <code>langchain-core >= 0.3</code>. Using <code>langchain-core < 0.3</code> will result in errors due to mixing of Pydantic v1 and v2 <code>BaseModels</code>.\n",
+    "        이 노트북은 Pydantic v2 <code>BaseModel</code>을 사용하며, 이는 <code>langchain-core >= 0.3</code>을 필요로 합니다. <code>langchain-core < 0.3</code>을 사용하면 Pydantic v1과 v2 <code>BaseModel</code>이 혼용되어 오류가 발생합니다.\n",
     "    </p>\n",
-    "</div>"
+    "</div>\n"
    ]
   },
   {
@@ -238,10 +232,10 @@
     "\n",
     "\n",
     "class Plan(BaseModel):\n",
-    "    \"\"\"Plan to follow in future\"\"\"\n",
+    "    \"\"\"앞으로 따를 계획\"\"\"\n",
     "\n",
     "    steps: List[str] = Field(\n",
-    "        description=\"different steps to follow, should be in sorted order\"\n",
+    "        description=\"따라야 할 여러 단계로, 순서대로 정렬되어 있어야 합니다\"\n",
     "    )"
    ]
   },
@@ -258,9 +252,7 @@
     "    [\n",
     "        (\n",
     "            \"system\",\n",
-    "            \"\"\"For the given objective, come up with a simple step by step plan. \\\n",
-    "This plan should involve individual tasks, that if executed correctly will yield the correct answer. Do not add any superfluous steps. \\\n",
-    "The result of the final step should be the final answer. Make sure that each step has all the information needed - do not skip steps.\"\"\",\n",
+    "            \"\"\"주어진 목표를 달성하기 위한 간단한 단계별 계획을 세우세요. 이 계획에는 개별 작업이 포함되어야 하며, 올바르게 수행하면 정답을 얻을 수 있어야 합니다. 불필요한 단계는 추가하지 마세요. 마지막 단계의 결과가 최종 답변이어야 합니다. 각 단계에 필요한 정보가 모두 포함되어 있는지 확인하고 단계를 건너뛰지 마세요.\"\"\"\n",
     "        ),\n",
     "        (\"placeholder\", \"{messages}\"),\n",
     "    ]\n",
@@ -288,12 +280,12 @@
     }
    ],
    "source": [
-    "planner.invoke(\n",
-    "    {\n",
-    "        \"messages\": [\n",
-    "            (\"user\", \"what is the hometown of the current Australia open winner?\")\n",
-    "        ]\n",
-    "    }\n",
+    "planner.invoke(",
+    "    {",
+    "        \"messages\": [",
+    "            (\"user\", \"현재 호주 오픈 우승자의 고향은 어디인가요?\")",
+    "        ]",
+    "    }",
     ")"
    ]
   },
@@ -302,9 +294,9 @@
    "id": "6e09ad9d-6f90-4bdc-bb43-b1ce94517c29",
    "metadata": {},
    "source": [
-    "## Re-Plan Step\n",
+    "## 재계획 단계\n",
     "\n",
-    "Now, let's create a step that re-does the plan based on the result of the previous step."
+    "이제 이전 단계의 결과에 따라 계획을 다시 세우는 단계를 만들어 보겠습니다.\n"
    ]
   },
   {
@@ -327,26 +319,23 @@
     "    \"\"\"Action to perform.\"\"\"\n",
     "\n",
     "    action: Union[Response, Plan] = Field(\n",
-    "        description=\"Action to perform. If you want to respond to user, use Response. \"\n",
-    "        \"If you need to further use tools to get the answer, use Plan.\"\n",
+    "        description=\"수행할 동작을 설명합니다. 사용자에게 바로 응답하려면 Response를 사용하고, 추가 도구가 필요하면 Plan을 사용하세요.\"\n",
     "    )\n",
     "\n",
     "\n",
     "replanner_prompt = ChatPromptTemplate.from_template(\n",
-    "    \"\"\"For the given objective, come up with a simple step by step plan. \\\n",
-    "This plan should involve individual tasks, that if executed correctly will yield the correct answer. Do not add any superfluous steps. \\\n",
-    "The result of the final step should be the final answer. Make sure that each step has all the information needed - do not skip steps.\n",
+    "    \"\"\"주어진 목표를 달성하기 위한 간단한 단계별 계획을 세우세요. 이 계획에는 개별 작업이 포함되어야 하며, 올바르게 수행하면 정답을 얻을 수 있어야 합니다. 불필요한 단계는 추가하지 마세요. 마지막 단계의 결과가 최종 답변이어야 합니다. 각 단계에 필요한 정보를 모두 포함하고, 단계를 건너뛰지 마세요.\n\"",
     "\n",
-    "Your objective was this:\n",
-    "{input}\n",
+    "    당신의 목표는 다음과 같습니다:\n",
+    "    {input}\n",
     "\n",
-    "Your original plan was this:\n",
-    "{plan}\n",
+    "    \n원래 계획은 다음과 같습니다:\n",
+    "    {plan}\n",
     "\n",
-    "You have currently done the follow steps:\n",
-    "{past_steps}\n",
+    "    \n현재까지 수행한 단계는 다음과 같습니다:\n",
+    "    {past_steps}\n",
     "\n",
-    "Update your plan accordingly. If no more steps are needed and you can return to the user, then respond with that. Otherwise, fill out the plan. Only add steps to the plan that still NEED to be done. Do not return previously done steps as part of the plan.\"\"\"\n",
+    "    \n계획을 이에 맞게 수정하세요. 더 이상 필요한 단계가 없고 사용자에게 답변할 수 있다면 그대로 응답하십시오. 그렇지 않다면 계획을 완성하세요. 여전히 수행해야 하는 단계만 계획에 추가하고 이미 완료된 단계는 포함하지 마세요.\"\"\"\n",
     ")\n",
     "\n",
     "\n",
@@ -360,9 +349,9 @@
    "id": "859abd13-6ba0-45ad-b341-e652dd5f755b",
    "metadata": {},
    "source": [
-    "## Create the Graph\n",
+    "## 그래프 생성\n",
     "\n",
-    "We can now create the graph!"
+    "이제 그래프를 생성해 봅시다!\n"
    ]
   },
   {
@@ -380,8 +369,7 @@
     "    plan = state[\"plan\"]\n",
     "    plan_str = \"\\n\".join(f\"{i+1}. {step}\" for i, step in enumerate(plan))\n",
     "    task = plan[0]\n",
-    "    task_formatted = f\"\"\"For the following plan:\n",
-    "{plan_str}\\n\\nYou are tasked with executing step {1}, {task}.\"\"\"\n",
+    "    task_formatted = f\"\"\"다음 계획에 따라:\n{plan_str}\n\n당신은 1단계인 {task} 작업을 실행해야 합니다.\"\"\"\n",
     "    agent_response = await agent_executor.ainvoke(\n",
     "        {\"messages\": [(\"user\", task_formatted)]}\n",
     "    )\n",
@@ -493,11 +481,11 @@
     }
    ],
    "source": [
-    "config = {\"recursion_limit\": 50}\n",
-    "inputs = {\"input\": \"what is the hometown of the mens 2024 Australia open winner?\"}\n",
-    "async for event in app.astream(inputs, config=config):\n",
-    "    for k, v in event.items():\n",
-    "        if k != \"__end__\":\n",
+    "config = {\"recursion_limit\": 50}",
+    "inputs = {\"input\": \"남자부 2024년 호주 오픈 우승자의 고향은 어디인가요?\"}",
+    "async for event in app.astream(inputs, config=config):",
+    "    for k, v in event.items():",
+    "        if k != \"__end__\":",
     "            print(v)"
    ]
   },
@@ -506,9 +494,9 @@
    "id": "8bf585a9-0f1e-4910-bd00-65e7bb05b6e6",
    "metadata": {},
    "source": [
-    "## Conclusion\n",
+    "## 결론\n",
     "\n",
-    "Congrats on making a plan-and-execute agent! One known limitations of the above design is that each task is still executed in sequence, meaning embarrassingly parallel operations all add to the total execution time. You could improve on this by having each task represented as a DAG (similar to LLMCompiler), rather than a regular list."
+    "계획 후 실행 에이전트를 완성했습니다! 위 설계의 한 가지 한계는 여전히 각 작업을 순차적으로 실행한다는 점입니다. 따라서 병렬로 처리할 수 있는 작업도 전체 실행 시간에 포함됩니다. 각 작업을 일반 리스트가 아닌 DAG로 표현하면 이 문제를 개선할 수 있습니다 (LLMCompiler와 유사).\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- translate all markdown content to Korean in `plan-and-execute.ipynb`
- localize prompt strings and example question to Korean

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684f935333a88325819fc5b32979ea39